### PR TITLE
fix for error triggered with multiple parallel sysscans during logica…

### DIFF
--- a/src/backend/access/heap/heapam.c
+++ b/src/backend/access/heap/heapam.c
@@ -1113,7 +1113,7 @@ heap_getnext(TableScanDesc sscan, ScanDirection direction)
 	 * level API but this is called from many places so we need to ensure it
 	 * here.
 	 */
-	if (unlikely(TransactionIdIsValid(CheckXidAlive) && !bsysscan))
+	if (unlikely(TransactionIdIsValid(CheckXidAlive) && (sysscan_depth == 0)))
 		elog(ERROR, "unexpected heap_getnext call during logical decoding");
 
 	/* Note: no locking manipulations needed */

--- a/src/backend/access/index/genam.c
+++ b/src/backend/access/index/genam.c
@@ -461,12 +461,12 @@ systable_beginscan(Relation heapRelation,
 	}
 
 	/*
-	 * If CheckXidAlive is set then set a flag to indicate that system table
-	 * scan is in-progress.  See detailed comments in xact.c where these
-	 * variables are declared.
+	 * If CheckXidAlive is set then increment a counter sysscan_depth to 
+	 * indicate that system table scan is in-progress.  See detailed comments
+	 * in xact.c where these variables are declared.
 	 */
 	if (TransactionIdIsValid(CheckXidAlive))
-		bsysscan = true;
+		sysscan_depth++;
 
 	return sysscan;
 }
@@ -616,11 +616,11 @@ systable_endscan(SysScanDesc sysscan)
 		UnregisterSnapshot(sysscan->snapshot);
 
 	/*
-	 * Reset the bsysscan flag at the end of the systable scan.  See detailed
+	 * Decrement the sysscan_depth counter at the end of the systable scan.  See detailed
 	 * comments in xact.c where these variables are declared.
 	 */
 	if (TransactionIdIsValid(CheckXidAlive))
-		bsysscan = false;
+		sysscan_depth--;
 
 	pfree(sysscan);
 }

--- a/src/backend/access/table/tableam.c
+++ b/src/backend/access/table/tableam.c
@@ -252,7 +252,7 @@ table_tuple_get_latest_tid(TableScanDesc scan, ItemPointer tid)
 	 * CheckXidAlive for catalog or regular tables.  See detailed comments in
 	 * xact.c where these variables are declared.
 	 */
-	if (unlikely(TransactionIdIsValid(CheckXidAlive) && !bsysscan))
+	if (unlikely(TransactionIdIsValid(CheckXidAlive) && (sysscan_depth == 0)))
 		elog(ERROR, "unexpected table_tuple_get_latest_tid call during logical decoding");
 
 	/*

--- a/src/backend/access/transam/xact.c
+++ b/src/backend/access/transam/xact.c
@@ -97,7 +97,6 @@ int			synchronous_commit = SYNCHRONOUS_COMMIT_ON;
  * concurrent aborts only in systable_* APIs.
  */
 TransactionId CheckXidAlive = InvalidTransactionId;
-bool		bsysscan = false;
 uint32		sysscan_depth = 0;
 /*
  * When running as a parallel worker, we place only a single

--- a/src/backend/access/transam/xact.c
+++ b/src/backend/access/transam/xact.c
@@ -98,7 +98,7 @@ int			synchronous_commit = SYNCHRONOUS_COMMIT_ON;
  */
 TransactionId CheckXidAlive = InvalidTransactionId;
 bool		bsysscan = false;
-
+uint32		sysscan_depth = 0;
 /*
  * When running as a parallel worker, we place only a single
  * TransactionStateData on the parallel worker's state stack, and the XID

--- a/src/backend/replication/logical/logical.c
+++ b/src/backend/replication/logical/logical.c
@@ -1875,7 +1875,7 @@ void
 ResetLogicalStreamingState(void)
 {
 	CheckXidAlive = InvalidTransactionId;
-	bsysscan = false;
+	sysscan_depth = 0;
 }
 
 /*

--- a/src/include/access/tableam.h
+++ b/src/include/access/tableam.h
@@ -1044,7 +1044,7 @@ table_scan_getnextslot(TableScanDesc sscan, ScanDirection direction, TupleTableS
 	 * CheckXidAlive for catalog or regular tables.  See detailed comments in
 	 * xact.c where these variables are declared.
 	 */
-	if (unlikely(TransactionIdIsValid(CheckXidAlive) && !bsysscan))
+	if (unlikely(TransactionIdIsValid(CheckXidAlive) && (sysscan_depth == 0)))
 		elog(ERROR, "unexpected table_scan_getnextslot call during logical decoding");
 
 	return sscan->rs_rd->rd_tableam->scan_getnextslot(sscan, direction, slot);
@@ -1228,7 +1228,7 @@ table_index_fetch_tuple(struct IndexFetchTableData *scan,
 	 * CheckXidAlive for catalog or regular tables.  See detailed comments in
 	 * xact.c where these variables are declared.
 	 */
-	if (unlikely(TransactionIdIsValid(CheckXidAlive) && !bsysscan))
+	if (unlikely(TransactionIdIsValid(CheckXidAlive) && (sysscan_depth == 0)))
 		elog(ERROR, "unexpected table_index_fetch_tuple call during logical decoding");
 
 	return scan->rel->rd_tableam->index_fetch_tuple(scan, tid, snapshot,
@@ -1274,7 +1274,7 @@ table_tuple_fetch_row_version(Relation rel,
 	 * valid CheckXidAlive for catalog or regular tables.  See detailed
 	 * comments in xact.c where these variables are declared.
 	 */
-	if (unlikely(TransactionIdIsValid(CheckXidAlive) && !bsysscan))
+	if (unlikely(TransactionIdIsValid(CheckXidAlive) && (sysscan_depth == 0)))
 		elog(ERROR, "unexpected table_tuple_fetch_row_version call during logical decoding");
 
 	return rel->rd_tableam->tuple_fetch_row_version(rel, tid, snapshot, slot);
@@ -1947,7 +1947,7 @@ table_scan_bitmap_next_block(TableScanDesc scan,
 	 * CheckXidAlive for catalog or regular tables.  See detailed comments in
 	 * xact.c where these variables are declared.
 	 */
-	if (unlikely(TransactionIdIsValid(CheckXidAlive) && !bsysscan))
+	if (unlikely(TransactionIdIsValid(CheckXidAlive) && (sysscan_depth == 0)))
 		elog(ERROR, "unexpected table_scan_bitmap_next_block call during logical decoding");
 
 	return scan->rs_rd->rd_tableam->scan_bitmap_next_block(scan,
@@ -1972,7 +1972,7 @@ table_scan_bitmap_next_tuple(TableScanDesc scan,
 	 * CheckXidAlive for catalog or regular tables.  See detailed comments in
 	 * xact.c where these variables are declared.
 	 */
-	if (unlikely(TransactionIdIsValid(CheckXidAlive) && !bsysscan))
+	if (unlikely(TransactionIdIsValid(CheckXidAlive) && (sysscan_depth == 0)))
 		elog(ERROR, "unexpected table_scan_bitmap_next_tuple call during logical decoding");
 
 	return scan->rs_rd->rd_tableam->scan_bitmap_next_tuple(scan,
@@ -1998,7 +1998,7 @@ table_scan_sample_next_block(TableScanDesc scan,
 	 * CheckXidAlive for catalog or regular tables.  See detailed comments in
 	 * xact.c where these variables are declared.
 	 */
-	if (unlikely(TransactionIdIsValid(CheckXidAlive) && !bsysscan))
+	if (unlikely(TransactionIdIsValid(CheckXidAlive) && (sysscan_depth == 0)))
 		elog(ERROR, "unexpected table_scan_sample_next_block call during logical decoding");
 	return scan->rs_rd->rd_tableam->scan_sample_next_block(scan, scanstate);
 }
@@ -2021,7 +2021,7 @@ table_scan_sample_next_tuple(TableScanDesc scan,
 	 * CheckXidAlive for catalog or regular tables.  See detailed comments in
 	 * xact.c where these variables are declared.
 	 */
-	if (unlikely(TransactionIdIsValid(CheckXidAlive) && !bsysscan))
+	if (unlikely(TransactionIdIsValid(CheckXidAlive) && (sysscan_depth == 0)))
 		elog(ERROR, "unexpected table_scan_sample_next_tuple call during logical decoding");
 	return scan->rs_rd->rd_tableam->scan_sample_next_tuple(scan, scanstate,
 														   slot);

--- a/src/include/access/xact.h
+++ b/src/include/access/xact.h
@@ -84,7 +84,6 @@ extern PGDLLIMPORT int synchronous_commit;
 
 /* used during logical streaming of a transaction */
 extern PGDLLIMPORT TransactionId CheckXidAlive;
-extern PGDLLIMPORT bool bsysscan;
 extern PGDLLIMPORT uint32 sysscan_depth;
 
 /*

--- a/src/include/access/xact.h
+++ b/src/include/access/xact.h
@@ -85,6 +85,7 @@ extern PGDLLIMPORT int synchronous_commit;
 /* used during logical streaming of a transaction */
 extern PGDLLIMPORT TransactionId CheckXidAlive;
 extern PGDLLIMPORT bool bsysscan;
+extern PGDLLIMPORT uint32 sysscan_depth;
 
 /*
  * Miscellaneous flag bits to record events which occur on the top level


### PR DESCRIPTION
Description:

There is an unexpected ERROR triggerred during logical decoding of a particular scenaio which leads to "wal_receiver" process abort and the client needs to reconnect to the server.

A decoder plugin is decoding an active transaction

The plugin make a call to "GetDefaultOpClass" to lookup an operator for a specific column.

The GetDefaultOpClass function triggers a bug:
a) "systable_beginscan" is called on a relation with id: "OperatorClassRelationId"
Since this is a system table and accessed using an index, a flag "bsysscan" is set to true, to mark that a sysscan is under progress.
b) Each tuple in the above relation is accessed sequentall by calling "systable_getnext" function. It is assumed that the flag "bssyscan" initialized during the call above will remain true. this is checked in "tableam.h" in function "table_scan_sample_next_tuple"
if (unlikely(TransactionIdIsValid(CheckXidAlive) && (sysscan_depth == 0)))
elog(ERROR, "unexpected table_scan_sample_next_tuple call during logical decoding");

c) But during the loop in "GetDefaultOpClass" to read tuples one by one, there is a call to "IsBinaryCoercible" which calls this sequence: IsBinaryCoercibleWithCast(), SearchSysCache2(), SearchCatCache2(), SearchCatCacheInternal(), SearchCatCacheMiss()

d) SearchCatCacheMiss funcion has a loop that goes through a relation one by one using the same "systable_beginscan", "systable_getnext", and "systable_endscan" calls..

e) the "systable_endscan" sets the "bsysscan" flag to "false" and hence triggers the ERROR in "tableam.h" in "table_scan_sample_next_tuple" function, during the loop in "GetDefaultOpClass" which assumed that "bsysscan" will be "true" for the duration of the while loop that reads the relation.

f) So instead of traching the "sysscan" by a "boolean flag" an "uint32" can be used to record the depth of how many times "systable_beginscan" was called. This counter "sysscan_depth" will be used to track if there is a "system table scan" is currently under progress.
Since this flag "bsysscan" is part of the extension API, this change leaves the decleration alone but does not use this flag for checking and using the "sysscan_depth" to track this.